### PR TITLE
UpdateRowsDeserializer.deserializeRow fails with EventDataDeserializationException No TableMapEventData has been found for table id

### DIFF
--- a/eventuate-local-java-cdc-connector-db-log-common/src/main/java/io/eventuate/local/db/log/common/DatabaseOffsetKafkaStore.java
+++ b/eventuate-local-java-cdc-connector-db-log-common/src/main/java/io/eventuate/local/db/log/common/DatabaseOffsetKafkaStore.java
@@ -43,7 +43,7 @@ public class DatabaseOffsetKafkaStore extends OffsetKafkaStore {
 
     CompletableFutureUtil.get(future);
 
-    logger.info("Offset is saved: {}", binlogFileOffset);
+    logger.debug("Offset is saved: {}", binlogFileOffset);
   }
 
   @Override

--- a/eventuate-local-java-cdc-connector-db-log-common/src/main/java/io/eventuate/local/db/log/common/DatabaseOffsetKafkaStore.java
+++ b/eventuate-local-java-cdc-connector-db-log-common/src/main/java/io/eventuate/local/db/log/common/DatabaseOffsetKafkaStore.java
@@ -42,6 +42,8 @@ public class DatabaseOffsetKafkaStore extends OffsetKafkaStore {
       );
 
     CompletableFutureUtil.get(future);
+
+    logger.info("Offset is saved: {}", binlogFileOffset);
   }
 
   @Override

--- a/eventuate-local-java-cdc-connector-mysql-binlog/src/main/java/io/eventuate/local/mysql/binlog/MySqlBinaryLogClient.java
+++ b/eventuate-local-java-cdc-connector-mysql-binlog/src/main/java/io/eventuate/local/mysql/binlog/MySqlBinaryLogClient.java
@@ -201,6 +201,8 @@ public class MySqlBinaryLogClient extends DbLogClient {
 
   private void handleBinlogEvent(Event event, Optional<BinlogFileOffset> binlogFileOffset) {
 
+    logger.info("Event received: {}", event);
+
     switch (event.getHeader().getEventType()) {
       case TABLE_MAP: {
         TableMapEventData tableMapEvent = event.getData();
@@ -385,7 +387,7 @@ public class MySqlBinaryLogClient extends DbLogClient {
   }
 
   private long extractOffset(Event event) {
-    return ((EventHeaderV4) event.getHeader()).getPosition();
+    return ((EventHeaderV4) event.getHeader()).getNextPosition();
   }
 
 

--- a/eventuate-local-java-cdc-connector-mysql-binlog/src/main/java/io/eventuate/local/mysql/binlog/MySqlBinaryLogClient.java
+++ b/eventuate-local-java-cdc-connector-mysql-binlog/src/main/java/io/eventuate/local/mysql/binlog/MySqlBinaryLogClient.java
@@ -201,7 +201,7 @@ public class MySqlBinaryLogClient extends DbLogClient {
 
   private void handleBinlogEvent(Event event, Optional<BinlogFileOffset> binlogFileOffset) {
 
-    logger.info("Event received: {}", event);
+    logger.debug("Event received: {}", event);
 
     switch (event.getHeader().getEventType()) {
       case TABLE_MAP: {
@@ -227,7 +227,7 @@ public class MySqlBinaryLogClient extends DbLogClient {
            mySqlBinlogEntryExtractor.refreshColumnOrder();
           }
         } else {
-          tableMapper.removeMapping(tableMapEvent);
+          tableMapper.addMapping(tableMapEvent);
         }
 
         dbLogMetrics.onBinlogEntryProcessed();

--- a/eventuate-local-java-cdc-connector-mysql-binlog/src/test/java/io/eventuate/local/mysql/binlog/MySqlBinaryLogClientTest.java
+++ b/eventuate-local-java-cdc-connector-mysql-binlog/src/test/java/io/eventuate/local/mysql/binlog/MySqlBinaryLogClientTest.java
@@ -43,7 +43,7 @@ public class MySqlBinaryLogClientTest {
       public void onEventSent(PublishedEvent event) {
         if (fail) {
           fail = false;
-          throw new IllegalStateException("Something happend");
+          throw new IllegalStateException("Something happened");
         }
       }
 


### PR DESCRIPTION
Fixed exception on cdc Restart.
See: https://github.com/eventuate-foundation/eventuate-cdc/issues/89#issuecomment-732082764

Fixed initial exceptions.
See: https://github.com/eventuate-foundation/eventuate-cdc/issues/89#issuecomment-732227158