### PR TITLE
when LSN over specified limit, then flush the LSN

### DIFF
--- a/eventuate-local-java-cdc-connector-common/src/main/java/io/eventuate/local/common/EventuateConfigurationProperties.java
+++ b/eventuate-local-java-cdc-connector-common/src/main/java/io/eventuate/local/common/EventuateConfigurationProperties.java
@@ -92,6 +92,9 @@ public class EventuateConfigurationProperties {
   @Value("${eventuate.cdc.kafka.batch.processing.max.batch.size:#{1000000}}")
   private int maxBatchSize;
 
+  @Value("${eventuate.cdc.postgres.max.lsn.diff.size.in.mb:#{1000}}")
+  private int maxLsnDiffInMb;
+
   public String getDbUserName() {
     return dbUserName;
   }
@@ -226,5 +229,13 @@ public class EventuateConfigurationProperties {
 
   public Integer getOutboxTablePartitions() {
     return outboxTablePartitions;
+  }
+
+  public int getMaxLsnDiffInMb() {
+    return maxLsnDiffInMb;
+  }
+
+  public void setMaxLsnDiffInMb(int maxLsnDiffInMb) {
+    this.maxLsnDiffInMb = maxLsnDiffInMb;
   }
 }

--- a/eventuate-local-java-cdc-connector-postgres-wal/src/main/java/io/eventuate/local/postgres/wal/PostgresConnectionFactory.java
+++ b/eventuate-local-java-cdc-connector-postgres-wal/src/main/java/io/eventuate/local/postgres/wal/PostgresConnectionFactory.java
@@ -1,0 +1,12 @@
+package io.eventuate.local.postgres.wal;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class PostgresConnectionFactory {
+    public Connection create(String dataSourceUrl, Properties props) throws SQLException {
+        return DriverManager.getConnection(dataSourceUrl, props);
+    }
+}

--- a/eventuate-local-java-cdc-connector-postgres-wal/src/test/java/io/eventuate/local/postgres/wal/PostgresWalBinlogEntryReaderMessageTableTestConfiguration.java
+++ b/eventuate-local-java-cdc-connector-postgres-wal/src/test/java/io/eventuate/local/postgres/wal/PostgresWalBinlogEntryReaderMessageTableTestConfiguration.java
@@ -56,7 +56,9 @@ public class PostgresWalBinlogEntryReaderMessageTableTestConfiguration {
             eventuateConfigurationProperties.getAdditionalServiceReplicationSlotName(),
             eventuateConfigurationProperties.getWaitForOffsetSyncTimeoutInMilliseconds(),
             new EventuateSchema(EventuateSchema.DEFAULT_SCHEMA),
-            eventuateConfigurationProperties.getOutboxId());
+            eventuateConfigurationProperties.getOutboxId(),
+            eventuateConfigurationProperties.getMaxLsnDiffInMb(),
+            new PostgresConnectionFactory());
   }
 
 }

--- a/eventuate-local-java-cdc-connector-postgres-wal/src/test/java/io/eventuate/local/postgres/wal/PostgresWalCdcIntegrationTestConfiguration.java
+++ b/eventuate-local-java-cdc-connector-postgres-wal/src/test/java/io/eventuate/local/postgres/wal/PostgresWalCdcIntegrationTestConfiguration.java
@@ -88,7 +88,9 @@ public class PostgresWalCdcIntegrationTestConfiguration {
             eventuateConfigurationProperties.getAdditionalServiceReplicationSlotName(),
             eventuateConfigurationProperties.getWaitForOffsetSyncTimeoutInMilliseconds(),
             new EventuateSchema(EventuateSchema.DEFAULT_SCHEMA),
-            eventuateConfigurationProperties.getOutboxId());
+            eventuateConfigurationProperties.getOutboxId(),
+            eventuateConfigurationProperties.getMaxLsnDiffInMb(),
+            new PostgresConnectionFactory());
   }
 
 

--- a/eventuate-local-java-cdc-connector-postgres-wal/src/test/java/io/eventuate/local/postgres/wal/PostgresWalLsnFlushTest.java
+++ b/eventuate-local-java-cdc-connector-postgres-wal/src/test/java/io/eventuate/local/postgres/wal/PostgresWalLsnFlushTest.java
@@ -1,0 +1,116 @@
+package io.eventuate.local.postgres.wal;
+
+import io.eventuate.common.jdbc.EventuateSchema;
+import io.eventuate.util.test.async.Eventually;
+import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.postgresql.jdbc.PgConnection;
+import org.postgresql.replication.LogSequenceNumber;
+import org.postgresql.replication.PGReplicationConnectionImpl;
+import org.postgresql.replication.PGReplicationStream;
+import org.postgresql.replication.fluent.ReplicationStreamBuilder;
+import org.postgresql.replication.fluent.logical.ChainedLogicalStreamBuilder;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.mockito.ArgumentMatchers.*;
+
+public class PostgresWalLsnFlushTest {
+
+    @Test
+    public void whenLsnOverDefaultLimitThenFlushLsn() throws SQLException {
+        PGReplicationConnectionImpl replicationConnection = Mockito.mock(PGReplicationConnectionImpl.class);
+        PGReplicationStream replicationStream = mockReplicationStream(replicationConnection);
+        Connection connection = mockConnection(replicationConnection);
+        Mockito.when(replicationStream.readPending()).thenReturn(null);
+
+        LogSequenceNumber lsn1 = LogSequenceNumber.valueOf("C3/8C9C12B0");
+        LogSequenceNumber lsn2 = LogSequenceNumber.valueOf("C2/E1649A00");
+
+        Mockito.when(replicationStream.getLastReceiveLSN()).thenReturn(lsn1);
+        Mockito.when(replicationStream.getLastFlushedLSN()).thenReturn(lsn2);
+
+        PostgresConnectionFactory connectionFactory = Mockito.mock(PostgresConnectionFactory.class);
+        Mockito.when(connectionFactory.create(any(), any())).thenReturn(connection);
+        PostgresWalClient client = createPostgresWalClient(connectionFactory);
+
+        runInSeparateThread(client::start);
+        Eventually.eventually(() -> Mockito.verify(replicationStream, Mockito.times(1)).setFlushedLSN(lsn1));
+        client.stop();
+    }
+
+    @Test
+    public void whenLsnUnderDefaultLimitThenDoNotFlushLsn() throws SQLException {
+        PGReplicationConnectionImpl replicationConnection = Mockito.mock(PGReplicationConnectionImpl.class);
+        PGReplicationStream replicationStream = mockReplicationStream(replicationConnection);
+        Connection connection = mockConnection(replicationConnection);
+        Mockito.when(replicationStream.readPending()).thenReturn(null);
+
+        LogSequenceNumber lsn1 = LogSequenceNumber.valueOf("C2/E1649A00");
+        LogSequenceNumber lsn2 = LogSequenceNumber.valueOf("C2/8C9C12B0");
+
+        Mockito.when(replicationStream.getLastReceiveLSN()).thenReturn(lsn1);
+        Mockito.when(replicationStream.getLastFlushedLSN()).thenReturn(lsn2);
+
+        PostgresConnectionFactory connectionFactory = Mockito.mock(PostgresConnectionFactory.class);
+        Mockito.when(connectionFactory.create(any(), any())).thenReturn(connection);
+        PostgresWalClient client = createPostgresWalClient(connectionFactory);
+
+        runInSeparateThread(client::start);
+        Eventually.eventually(() -> Mockito.verify(replicationStream, Mockito.times(0)).setFlushedLSN(any()));
+        client.stop();
+    }
+
+    private void runInSeparateThread(Runnable callback) {
+        new Thread(callback).start();
+    }
+
+    private Connection mockConnection(PGReplicationConnectionImpl replicationConnection) throws SQLException {
+        Connection connection = Mockito.mock(Connection.class);
+        PgConnection pgConnection = Mockito.mock(PgConnection.class);
+        Mockito.when(pgConnection.getReplicationAPI()).thenReturn(replicationConnection);
+        Mockito.when(connection.unwrap(any())).thenReturn(pgConnection);
+        return connection;
+    }
+
+    private PGReplicationStream mockReplicationStream(PGReplicationConnectionImpl replicationConnection) throws SQLException {
+        ReplicationStreamBuilder replicationStreamBuilder = Mockito.mock(ReplicationStreamBuilder.class);
+        ChainedLogicalStreamBuilder chainedLogicalStreamBuilder = Mockito.spy(ChainedLogicalStreamBuilder.class);
+        Mockito.when(chainedLogicalStreamBuilder.withSlotName(any())).thenReturn(chainedLogicalStreamBuilder);
+        Mockito.when(chainedLogicalStreamBuilder.withSlotOption(any(), anyBoolean())).thenReturn(chainedLogicalStreamBuilder);
+        Mockito.when(chainedLogicalStreamBuilder.withStatusInterval(anyInt(), any())).thenReturn(chainedLogicalStreamBuilder);
+        Mockito.when(replicationConnection.replicationStream()).thenReturn(replicationStreamBuilder);
+        Mockito.when(replicationStreamBuilder.logical()).thenReturn(chainedLogicalStreamBuilder);
+        PGReplicationStream replicationStream = Mockito.mock(PGReplicationStream.class);
+        Mockito.when(chainedLogicalStreamBuilder.start()).thenReturn(replicationStream);
+        return replicationStream;
+    }
+
+    private PostgresWalClient createPostgresWalClient(PostgresConnectionFactory connectionFactory) {
+        return new PostgresWalClient(
+                new LoggingMeterRegistry(),
+                "jdbc:postgresql://localhost:5432/eventuate",
+                "postgres",
+                "postgres",
+                1000,
+                1000,
+                1000,
+                1000,
+                "test_slot",
+                Mockito.mock(DataSource.class),
+                "test_reader",
+                1000,
+                1000,
+                1000,
+                "test_additional_slot",
+                1000,
+                new EventuateSchema(EventuateSchema.DEFAULT_SCHEMA),
+                1L,
+                1000,
+                connectionFactory
+        );
+    }
+}

--- a/eventuate-local-java-cdc-connector-unified/src/main/java/io/eventuate/local/unified/cdc/pipeline/dblog/postgreswal/factory/PostgresWalCdcPipelineReaderFactory.java
+++ b/eventuate-local-java-cdc-connector-unified/src/main/java/io/eventuate/local/unified/cdc/pipeline/dblog/postgreswal/factory/PostgresWalCdcPipelineReaderFactory.java
@@ -2,6 +2,7 @@ package io.eventuate.local.unified.cdc.pipeline.dblog.postgreswal.factory;
 
 import io.eventuate.common.jdbc.EventuateSchema;
 import io.eventuate.local.common.ConnectionPoolConfigurationProperties;
+import io.eventuate.local.postgres.wal.PostgresConnectionFactory;
 import io.eventuate.local.postgres.wal.PostgresWalClient;
 import io.eventuate.local.unified.cdc.pipeline.common.factory.CommonCdcPipelineReaderFactory;
 import io.eventuate.local.unified.cdc.pipeline.dblog.postgreswal.properties.PostgresWalCdcPipelineReaderProperties;
@@ -53,6 +54,8 @@ public class PostgresWalCdcPipelineReaderFactory
             readerProperties.getAdditionalServiceReplicationSlotName(),
             readerProperties.getWaitForOffsetSyncTimeoutInMilliseconds(),
             new EventuateSchema(readerProperties.getMonitoringSchema()),
-            readerProperties.getOutboxId());
+            readerProperties.getOutboxId(),
+            readerProperties.getMaxLsnDiffInMb(),
+            new PostgresConnectionFactory());
   }
 }

--- a/eventuate-local-java-cdc-connector-unified/src/main/java/io/eventuate/local/unified/cdc/pipeline/dblog/postgreswal/properties/PostgresWalCdcPipelineReaderProperties.java
+++ b/eventuate-local-java-cdc-connector-unified/src/main/java/io/eventuate/local/unified/cdc/pipeline/dblog/postgreswal/properties/PostgresWalCdcPipelineReaderProperties.java
@@ -10,6 +10,8 @@ public class PostgresWalCdcPipelineReaderProperties extends CommonDbLogCdcPipeli
   private String additionalServiceReplicationSlotName = "eventuate_offset_control_slot";
   private long waitForOffsetSyncTimeoutInMilliseconds = 60000;
 
+  private int maxLsnDiffInMb = 1000;
+
   public Integer getPostgresWalIntervalInMilliseconds() {
     return postgresWalIntervalInMilliseconds;
   }
@@ -48,5 +50,13 @@ public class PostgresWalCdcPipelineReaderProperties extends CommonDbLogCdcPipeli
 
   public void setWaitForOffsetSyncTimeoutInMilliseconds(long waitForOffsetSyncTimeoutInMilliseconds) {
     this.waitForOffsetSyncTimeoutInMilliseconds = waitForOffsetSyncTimeoutInMilliseconds;
+  }
+
+  public int getMaxLsnDiffInMb() {
+    return maxLsnDiffInMb;
+  }
+
+  public void setMaxLsnDiffInMb(int maxLsnDiffInMb) {
+    this.maxLsnDiffInMb = maxLsnDiffInMb;
   }
 }


### PR DESCRIPTION
This PR is related to [this issue](https://github.com/eventuate-foundation/eventuate-cdc/issues/147).
Also I extracted the connection creation in PostgresWalClient to a separate class, so that it would be better to test it. I decided to mock the entire thing, because simulating LSN difference in integration tests seemed potentially unreliable.