### PR TITLE
#147 flush lsn when processing monitoring message

### DIFF
--- a/eventuate-local-java-cdc-connector-postgres-wal/src/main/java/io/eventuate/local/postgres/wal/PostgresWalClient.java
+++ b/eventuate-local-java-cdc-connector-postgres-wal/src/main/java/io/eventuate/local/postgres/wal/PostgresWalClient.java
@@ -281,6 +281,7 @@ public class PostgresWalClient extends DbLogClient {
       int index = Arrays.asList(change.getColumnnames()).indexOf("last_time");
       dbLogMetrics.onLagMeasurementEventReceived(Long.parseLong(change.getColumnvalues()[index]));
       onEventReceived();
+      offsetProcessor.saveOffset(CompletableFuture.completedFuture(Optional.of(stream.getLastReceiveLSN())));
     });
   }
 


### PR DESCRIPTION
Did the change that was mentioned under the #148 PR. Since it's such a small change and I didn't find similar tests for the existing LSN flushing logic, decided to omit them. But can provide them, if needed.